### PR TITLE
fix: Fix no required body in types

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+README.MD

--- a/src/types/schemeTypes.ts
+++ b/src/types/schemeTypes.ts
@@ -1,6 +1,6 @@
 import type { FilterKeys, PathsWithMethod } from "openapi-typescript-helpers";
 import type { MethodType } from "../const/methods.js";
-import type { FilterKeyOrNever } from "./utils.js";
+import type { FilterKeyOrNever, IsFieldOptional } from "./utils.js";
 
 /**
  * @description Define possible field types in OpenAPI schema
@@ -35,6 +35,15 @@ export type SchemaType = {
 };
 
 /**
+ * @description Checks for the existence of an internal route. If it exists, it retrieves it
+ */
+export type SchemeRoute<
+  Schema extends SchemaType,
+  Method extends MethodType,
+  Route extends RoutesForMethod<Schema, Method>,
+> = FilterKeys<FilterKeys<Schema, Route>, Method>;
+
+/**
  * @description Checks for the existence of an internal field. If it exists, it retrieves it
  */
 export type SchemeRouteField<
@@ -42,7 +51,7 @@ export type SchemeRouteField<
   Method extends MethodType,
   Route extends RoutesForMethod<Schema, Method>,
   Field extends FieldType,
-> = FilterKeys<FilterKeys<FilterKeys<Schema, Route>, Method>, Field>;
+> = FilterKeys<SchemeRoute<Schema, Method, Route>, Field>;
 
 /**
  * @description Extracts all path parameters for a given route and method in the schema
@@ -85,10 +94,33 @@ export type RouteRequestBody<
   Schema extends SchemaType,
   Method extends MethodType,
   Route extends RoutesForMethod<Schema, Method>,
-> = FilterKeys<
-  FilterKeys<SchemeRouteField<Schema, Method, Route, "requestBody">, "content">,
-  TargetMimeTypes
->;
+> =
+  IsFieldOptional<
+    SchemeRoute<Schema, Method, Route>,
+    "requestBody"
+  > extends true
+    ?
+        | FilterKeys<
+            FilterKeys<
+              FilterKeys<
+                Required<SchemeRoute<Schema, Method, Route>>,
+                "requestBody"
+              >,
+              "content"
+            >,
+            TargetMimeTypes
+          >
+        | undefined
+    : FilterKeys<
+        FilterKeys<
+          FilterKeys<
+            FilterKeys<FilterKeys<Schema, Route>, Method>,
+            "requestBody"
+          >,
+          "content"
+        >,
+        TargetMimeTypes
+      >;
 
 /**
  * @example

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -29,6 +29,19 @@ export type MakeNeverEmpty<T> = {
 export type NotNever<T> = [T] extends [never] ? false : true;
 
 /**
+ * @description Type utility to determine if a field in an object type `T` can be `undefined`.
+ * Returns `true` if the field `K` of type `T` can be `undefined`, otherwise `false`.
+ *
+ * @template T - The object type to check.
+ * @template K - The key of the field in the object type `T` to check for `undefined`.
+ */
+export type IsFieldOptional<T, K extends string> = K extends keyof T
+  ? undefined extends T[K]
+    ? true
+    : false
+  : false;
+
+/**
  * @description Type utility to filter the key `K` from type `T`.
  * Returns the type of `T[K]` if `K` is a key of `T` and `T[K]` is not `undefined`.
  * Otherwise, returns `never`.

--- a/test/example-api.test.ts
+++ b/test/example-api.test.ts
@@ -1,0 +1,42 @@
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+import { beforeAll, describe, expect, test } from "vitest";
+import { OpenApiAxios } from "../src/index.js";
+import { type components, type paths } from "./fixtures/example.api.js";
+
+let mockAdapter: MockAdapter;
+let api: OpenApiAxios<paths, "axios">;
+
+const petMock: components["schemas"]["Pet"] = {
+  id: 1,
+  name: "pet",
+  photoUrls: ["http://test.ru"],
+};
+
+beforeAll(() => {
+  const axiosInstance = axios.create({});
+  api = new OpenApiAxios<paths, "axios">(axiosInstance, {
+    validStatus: "axios",
+  });
+
+  // @ts-expect-error @TODO See issue #4 - https://github.com/web-bee-ru/openapi-axios/issues/4
+  mockAdapter = new MockAdapter(axiosInstance);
+
+  mockAdapter.onPost("/pet").reply(200);
+  mockAdapter.onPut("/pet").reply(200);
+});
+
+describe("Body serializer", () => {
+  test("Check required body", async () => {
+    const { status } = await api.put("/pet", petMock);
+    expect(status).toBe(200);
+  });
+
+  test("Check no required body", async () => {
+    const { status } = await api.post("/pet", petMock);
+    const { status: status2 } = await api.post("/pet", undefined);
+
+    expect(status).toBe(200);
+    expect(status2).toBe(200);
+  });
+});

--- a/test/fixtures/example.api.yml
+++ b/test/fixtures/example.api.yml
@@ -105,7 +105,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: "#/components/schemas/Pet"
-        required: true
+        required: false
       responses:
         "200":
           description: Successful operation

--- a/test/params.test-d.ts
+++ b/test/params.test-d.ts
@@ -40,7 +40,13 @@ describe("Params type tests", () => {
 
   test("Check is method with body, body params type are may be required", () => {
     expectTypeOf<
-      IsNotUndefinable<FetcherWithBodyParameters<paths, "post", "/pet">[1]>
+      IsNotUndefinable<FetcherWithBodyParameters<paths, "put", "/pet">[1]>
+    >().toMatchTypeOf<true>();
+  });
+
+  test("Check is method with body, body params type are may be optional", () => {
+    expectTypeOf<
+      IsUndefinable<FetcherWithBodyParameters<paths, "post", "/pet">[1]>
     >().toMatchTypeOf<true>();
   });
 


### PR DESCRIPTION
There was an error where it was impossible to pass an object to the request body if it was not required by the schema. Error where you can't assign anything to undefined

```
requestBody?: {
            content: {
                "application/json": components["schemas"]["Pet"];
                "application/xml": components["schemas"]["Pet"];
                "application/x-www-form-urlencoded": components["schemas"]["Pet"];
            };
        };
```

```
post:
      tags:
        - pet
      summary: Add a new pet to the store
      description: Add a new pet to the store
      operationId: addPet
      requestBody:
        description: Create a new pet in the store
        content:
          application/json:
            schema:
              $ref: "#/components/schemas/Pet"
          application/xml:
            schema:
              $ref: "#/components/schemas/Pet"
          application/x-www-form-urlencoded:
            schema:
              $ref: "#/components/schemas/Pet"
        required: false
```