### PR TITLE
fix cjs/package.json creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prepare": "husky",
     "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "rimraf ./dist && tsc -p tsconfig.build.json",
-    "build:cjs": "rimraf ./cjs && tsc -p tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > ./cjs/package.json",
+    "build:cjs": "rimraf ./cjs && tsc -p tsconfig.cjs.json && echo \"{\\\"type\\\":\\\"commonjs\\\"}\" > ./cjs/package.json",
     "format": "prettier --write .",
     "lint": "eslint . && prettier -c .",
     "prettier:fix": "prettier -w .",


### PR DESCRIPTION
The current script `npm run build:cjs` produces a file that is wrapped in single quotes:
```json
'{"type": "commonjs"}'
```

This change should fix that.